### PR TITLE
Make uploaded files public by default

### DIFF
--- a/s3.js
+++ b/s3.js
@@ -26,6 +26,7 @@ S3FileStore.prototype.save = function (image) {
         return putObject({
             Bucket: config.aws.bucket,
             Key: filename,
+            ACL: 'public-read',
             Body: buffer,
             ContentType: image.type,
             CacheControl: 'max-age=' + (30 * 24 * 60 * 60) // 30 days


### PR DESCRIPTION
Hi, the idea is to make every file uploaded to the S3 public. The files are going be accessed by the blog readers, so they need to be publicly available.

Regards.
