### PR TITLE
Support Cloudfront as a CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,19 @@ AWS S3 file storage module for Ghost blogs.
 
 In your Ghost config.js file, under "development" and/or "production", add:
 
-	aws: {
-	    accessKeyId: 'your AWS access key id',
-	    secretAccessKey: 'your AWS secret access key',
-	    bucket: 'your bucket name',
-	    region: 'the AWS region your bucket is in; e.g.: eu-west-1'
-	}
+```javascript
+aws: {
+    accessKeyId: 'your AWS access key id',
+    secretAccessKey: 'your AWS secret access key',
+    bucket: 'your bucket name',
+    region: 'the AWS region your bucket is in; e.g.: eu-west-1',
+    cloudfront: 'the cloufront domain; e.g.: djq7m1gww7pf8e' // Optional
+}
+```
+
+The `cloudfront` key is optional and should only be filled is Cloudfront is
+being used as a content distribution network. Is the option is not present, the
+files will be served directly from S3.
 
 Note: for enhanced security, it is recommended that you use environment variables instead of hard-coding the values in your config.js file.
 

--- a/s3.js
+++ b/s3.js
@@ -31,7 +31,11 @@ S3FileStore.prototype.save = function (image) {
             CacheControl: 'max-age=' + (30 * 24 * 60 * 60) // 30 days
         });
     }).then(function (result) {
-        return 'https://' + config.aws.bucket + '.s3.amazonaws.com/' + filename;
+        if (config.aws.cloudfront) {
+            return 'https://' + config.aws.cloudfront + '.cloudfront.net/' + filename;
+        } else {
+            return 'https://' + config.aws.bucket + '.s3.amazonaws.com/' + filename;
+        }
     }).catch(function (e) {
         errors.logError(e);
         return Promise.reject(e);


### PR DESCRIPTION
Add a new non-required option to be able to use Cloudfront as a CDN. The option asks for the assigned Cloudfront domain for the bucket. If the option is not present in `config.js` then the returned url will point to the S3 directly.

Regards.
